### PR TITLE
add function html() to get outerHtml or outerXml 

### DIFF
--- a/lib/src/model/base.dart
+++ b/lib/src/model/base.dart
@@ -47,6 +47,9 @@ abstract class XPathNode<T> {
   /// Return the concatenated text of this node and all its descendants
   String? get text;
 
+  /// Return the origin content of this node that include tags
+  String? get html;
+
   /// Return the parent node of this node, or `null` if there is none.
   XPathNode<T>? get parent;
 

--- a/lib/src/model/html.dart
+++ b/lib/src/model/html.dart
@@ -36,6 +36,9 @@ class HtmlNodeTree extends XPathNode<Node> {
   String? get text => node.text;
 
   @override
+  String? get html => element.outerHtml;
+
+  @override
   String toString() => node.toString();
 
   @override

--- a/lib/src/model/xml.dart
+++ b/lib/src/model/xml.dart
@@ -28,6 +28,9 @@ class XmlNodeTree extends XPathNode<XmlNode> {
   String? get text => node.text;
 
   @override
+  String? get html => node.outerXml;
+
+  @override
   bool operator ==(Object other) => other is XmlNodeTree && other.node == node;
 
   @override

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -1,5 +1,3 @@
-import 'package:html/dom.dart';
-import 'package:xml/xml.dart';
 import 'package:xpath_selector/src/reg.dart';
 import 'package:xpath_selector/src/selector.dart';
 

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -1,3 +1,5 @@
+import 'package:html/dom.dart';
+import 'package:xml/xml.dart';
 import 'package:xpath_selector/src/reg.dart';
 import 'package:xpath_selector/src/selector.dart';
 
@@ -11,8 +13,7 @@ List<List<Selector>> parseSelectGroup(String xpath) {
 
   for (final _path in combine) {
     final path = _path.trim();
-    final xpathItem =
-        xpathGroup.allMatches(path).map((e) => e.group(0)!.trim());
+    final xpathItem = xpathGroup.allMatches(path).map((e) => e.group(0)!.trim());
     selectorList.add(xpathItem.map(_parseSelector).toList());
   }
 
@@ -54,10 +55,8 @@ Selector _parseSelector(String input) {
   for (final predicate in predicates) {
     nodeTest = nodeTest.replaceAll(predicate.group(0) ?? '', '');
   }
-  final predicateList = predicates
-      .map((e) => e.namedGroup('predicate'))
-      .whereType<String>()
-      .toList();
+  final predicateList =
+      predicates.map((e) => e.namedGroup('predicate')).whereType<String>().toList();
 
   if (nodeTest == '.') {
     axis = AxesAxis.self;
@@ -155,8 +154,7 @@ List<String?> parseAttr({
         }
       } else if (lastSelector.function != null) {
         // function
-        result.add(
-            elementFunction(node: element, function: lastSelector.function!));
+        result.add(elementFunction(node: element, function: lastSelector.function!));
       } else if (lastSelector.axes.axis == AxesAxis.attribute) {
         // attr
         if (lastSelector.axes.nodeTest == '*') {
@@ -179,6 +177,10 @@ String? elementFunction({required XPathNode node, required String function}) {
       case 'text()':
       case 'string()':
         return node.text ?? '';
+      case 'html()':
+        return node.isElement
+            ? (node.node as Element).outerHtml
+            : (node.node as XmlNode).outerXml;
       case 'name()':
       case 'qualified()':
         return node.name?.qualified;

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -178,9 +178,7 @@ String? elementFunction({required XPathNode node, required String function}) {
       case 'string()':
         return node.text ?? '';
       case 'html()':
-        return node.isElement
-            ? (node.node as Element).outerHtml
-            : (node.node as XmlNode).outerXml;
+        return node.html ?? '';
       case 'name()':
       case 'qualified()':
         return node.name?.qualified;


### PR DESCRIPTION
add function html() to get outerHtml or outerXml and support `//h3[contains(html(), "data-bid")]/text()` or `//h3/html()`

加上一个`html()`方法可以应对更多情形
类似jquery里会有这样的方法
还有一些java的xpath库也有这种扩展
甚至可以继续加 outerHtml() 和 outerXml() 方法 但是嫌弃它比较啰嗦